### PR TITLE
[FEAT] Provider enabled flag

### DIFF
--- a/src/components/CursorifyProvider/CursorifyProvider.tsx
+++ b/src/components/CursorifyProvider/CursorifyProvider.tsx
@@ -29,19 +29,20 @@ type Props = PropsWithChildren<{
   opacity?: CusorifyStateType['opacity']
   defaultCursorVisible?: CusorifyStateType['defaultCursorVisible']
   breakpoint?: CusorifyStateType['breakpoint']
+  enabled?: boolean
 }>
 
-export const CursorifyProvider: React.FC<Props> = ({ children, ...props }) => {
+export const CursorifyProvider: React.FC<Props> = ({ children, enabled, ...props }) => {
   const [state, dispatch] = useCursorifyReducer({
     ...defaultCursorifyState,
     ...props,
   })
 
-  const enabled = useBreakpoint(state.breakpoint)
+  const breakpointEnabled = useBreakpoint(state.breakpoint)
   return (
     <CursorifyStateContext.Provider value={state}>
       <CursorifyDispatchContext.Provider value={dispatch}>
-        {enabled && <Cursorify>{state.cursor}</Cursorify>}
+        {enabled && breakpointEnabled && <Cursorify>{state.cursor}</Cursorify>}
         {children}
       </CursorifyDispatchContext.Provider>
     </CursorifyStateContext.Provider>


### PR DESCRIPTION
<!-- 1. Verify PR Title -->
<!-- PR Title example: `[FIX | REFACTOR | FEAT | UPDATE | DOCUMENTATION] repair the page layout` -->

<!-- 2. Provide Description of the changes -->

## Description
Added `enabled` prop to `CursorifyProvider`. Currently, the provider can be enabled/disabled based on breakpoints only. This change allows users to enable/disable the provider based on more complex conditions (e.g., state change, etc).

<!--
- provide a description of the changes made. If there are some pending TODOs, include them there as well.
- Any guidance for reviewers to better understand the changes.
- Any visuals (screenshots, screen recordings) that can give assurance that the changes are safe to merge.
-->

<!-- 4. Make sure the following actions are checked before finalising your PR -->

## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
